### PR TITLE
fix: Added quotes around password in unlock command

### DIFF
--- a/bw_export.sh
+++ b/bw_export.sh
@@ -194,7 +194,7 @@ then
 fi
 
 #Unlock the vault
-session_key=$(bw unlock $bw_password --raw)
+session_key=$(bw unlock "$bw_password" --raw)
 
 #Verify that unlock succeeded
 if [[ $session_key == "" ]]


### PR DESCRIPTION
If master password included spaces it would not work, need quotes around bw_password to fix